### PR TITLE
Fix CBC AES encryption + add test for block longer than 128 bit

### DIFF
--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/AES.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/AES.kt
@@ -181,22 +181,17 @@ class AES(val keyWords: IntArray) {
 			var s3 = 0
 
 			for (n in 0 until wordsLength step 4) {
-				val t0 = words[n + 0]
-				val t1 = words[n + 1]
-				val t2 = words[n + 2]
-				val t3 = words[n + 3]
-
-				aes.encryptBlock(words, n)
-
 				words[n + 0] = words[n + 0] xor s0
 				words[n + 1] = words[n + 1] xor s1
 				words[n + 2] = words[n + 2] xor s2
 				words[n + 3] = words[n + 3] xor s3
 
-				s0 = t0
-				s1 = t1
-				s2 = t2
-				s3 = t3
+                aes.encryptBlock(words, n)
+
+                s0 = words[n + 0]
+                s1 = words[n + 1]
+                s2 = words[n + 2]
+                s3 = words[n + 3]
 			}
 			return words.toByteArray()
 		}

--- a/krypto/src/commonTest/kotlin/com/soywiz/krypto/AESTest.kt
+++ b/krypto/src/commonTest/kotlin/com/soywiz/krypto/AESTest.kt
@@ -11,6 +11,14 @@ class AESTest {
 		assertEquals(plainText.toHexStringLower(), AES.decryptAes128Cbc(cipherText, cipherKey).toHexStringLower())
 		assertEquals(cipherText.toHexStringLower(), AES.encryptEes128Cbc(plainText, cipherKey).toHexStringLower())
 	}
+
+	@Test
+	fun longName() {
+		val plainText = Hex.decode("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+		val cipherKey = Hex.decode("000102030405060708090a0b0c0d0e0f")
+		val cipherText = AES.encryptEes128Cbc(plainText, cipherKey)
+		assertEquals(plainText.toHexStringLower(), AES.decryptAes128Cbc(cipherText, cipherKey).toHexStringLower())
+	}
 }
 
 /*


### PR DESCRIPTION
When I try to use AES encryption for block more than 128 bits I found, that it doesn't work. Find solution, that implementation is wrong for encryption, it must not be like decryption.
[https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation](url)