### PR TITLE
Implement AES PKCS7Padding

### DIFF
--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/Padding.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/Padding.kt
@@ -1,0 +1,5 @@
+package com.soywiz.krypto
+
+enum class Padding {
+    NoPadding, PKCS7Padding
+}

--- a/krypto/src/commonTest/kotlin/com/soywiz/krypto/AESTest.kt
+++ b/krypto/src/commonTest/kotlin/com/soywiz/krypto/AESTest.kt
@@ -19,6 +19,20 @@ class AESTest {
 		val cipherText = AES.encryptAes128Cbc(plainText, cipherKey)
 		assertEquals(plainText.toHexStringLower(), AES.decryptAes128Cbc(cipherText, cipherKey).toHexStringLower())
 	}
+
+    @Test
+    fun pkcs7padding() {
+        val data = ByteArray(128){it.toByte()}
+        for (i in data.indices) {
+            // plainText is [0 .. i]
+            val plainText = ByteArray(i){it.toByte()}
+            println(plainText.contentToString())
+            val cipherKey = byteArrayOf(1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4)
+            val encryptedText = AES.encryptAes128Cbc(plainText, cipherKey, Padding.PKCS7Padding)
+            val decryptedText = AES.decryptAes128Cbc(encryptedText, cipherKey, Padding.PKCS7Padding)
+            assertEquals(plainText.toHexStringLower(), decryptedText.toHexStringLower())
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
Add padding parameter for `fun encryptAes128Cbc` and `fun decryptAes128Cbc`. 
Users can select `NoPadding` or `PKCS7Padding`, and default value is `NoPadding`.