### PR TITLE
fix Hasher reset

### DIFF
--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/Hasher.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/Hasher.kt
@@ -16,6 +16,8 @@ abstract class Hasher(val chunkSize: Int, val digestSize: Int) {
 
     fun reset(): Hasher {
         coreReset()
+        writtenInChunk = 0
+        totalWritten = 0L
         return this
     }
 


### PR DESCRIPTION
I think `writtenInChunk` and `totalWritten` also should be reset in `reset()` function.
otherwise, 
```kotlin
val sha1 = SHA1()
sha1.update(ByteArray(16))
val s1 = sha1.digest().bytes
        
sha1.reset()
sha1.update(ByteArray(20))
val s2 = sha1.digest().bytes // Exception here
```